### PR TITLE
Update to actual laravel and imgix version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Laravel package for generating URLs with [Imgix](https://www.imgix.com/).
 
 Make sure all dependencies have been installed before moving on:
 
-* [PHP](http://php.net/manual/en/install.php) >= 5.6
+* [PHP](http://php.net/manual/en/install.php) >= 7.2
 * [Composer](https://getcomposer.org/download/)
 
 ## Install

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
     ],
     "require": {
         "php": ">=5.6.4",
-        "illuminate/support": "~5.4",
-        "imgix/imgix-php": "~1.1"
+        "illuminate/support": "^6.0",
+        "imgix/imgix-php": "^3.0"
     },
     "require-dev": {
         "mockery/mockery": "~0.9",

--- a/composer.json
+++ b/composer.json
@@ -18,15 +18,15 @@
         }
     ],
     "require": {
-        "php": ">=5.6.4",
+        "php": ">=7.2",
         "illuminate/support": "^6.0",
         "imgix/imgix-php": "^3.0"
     },
     "require-dev": {
-        "mockery/mockery": "~0.9",
-        "orchestra/testbench": "~3.4",
-        "phpunit/phpunit": "~5.7",
-        "squizlabs/php_codesniffer": "~3.0"
+        "mockery/mockery": "^1.0",
+        "orchestra/testbench": "^4.0",
+        "phpunit/phpunit": "^8.0",
+        "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {
         "files": [

--- a/config/imgix.php
+++ b/config/imgix.php
@@ -6,7 +6,7 @@ return [
      * @see https://github.com/imgix/imgix-php
      */
 
-    'domain' =>  'test.imgix.net',
+    'domain' => 'test.imgix.net',
 
     'useHttps' => false,
 

--- a/config/imgix.php
+++ b/config/imgix.php
@@ -6,15 +6,11 @@ return [
      * @see https://github.com/imgix/imgix-php
      */
 
-    'domains' => [
-        'test.imgix.net',
-    ],
+    'domain' =>  'test.imgix.net',
 
     'useHttps' => false,
 
     'signKey' => '',
-
-    'shardStrategy' => \Imgix\ShardStrategy::CRC,
 
     'includeLibraryParam' => true,
 

--- a/src/Imgix.php
+++ b/src/Imgix.php
@@ -27,7 +27,7 @@ class Imgix
      * Create an imgix url for the given path.
      *
      * @param string $path
-     * @param array $params
+     * @param array  $params
      *
      * @return string
      */

--- a/src/ImgixServiceProvider.php
+++ b/src/ImgixServiceProvider.php
@@ -39,7 +39,7 @@ class ImgixServiceProvider extends ServiceProvider
         });
 
         $this->app->singleton(Imgix::class, function ($app) {
-            return new Imgix($app[UrlBuilder::class]);
+            return new Imgix($app[ UrlBuilder::class ]);
         });
 
         $this->app->alias(Imgix::class, static::ALIAS);

--- a/src/ImgixServiceProvider.php
+++ b/src/ImgixServiceProvider.php
@@ -31,10 +31,9 @@ class ImgixServiceProvider extends ServiceProvider
     {
         $this->app->singleton(UrlBuilder::class, function () {
             return new UrlBuilder(
-                config('imgix.domains'),
+                config('imgix.domain'),
                 config('imgix.useHttps', false),
                 config('imgix.signKey', ''),
-                config('imgix.shardStrategy', ShardStrategy::CRC),
                 config('imgix.includeLibraryParam', true)
             );
         });

--- a/tests/Unit/ImgixTest.php
+++ b/tests/Unit/ImgixTest.php
@@ -15,13 +15,13 @@ class ImgixTest extends TestCase
     /** @var \Nasyrov\Laravel\Imgix\Imgix */
     protected $imgix;
 
-    protected function setUp()
+    protected function setUp() :void
     {
         $this->urlBuilder = Mockery::mock(UrlBuilder::class);
         $this->imgix      = new Imgix($this->urlBuilder);
     }
 
-    protected function tearDown()
+    protected function tearDown() :void
     {
         Mockery::close();
     }


### PR DESCRIPTION
This PR will update the package to laravel >= 6.0 and imgix-php >= 3.0.

This will include some breaking changes to the package due to changes in the required packages:

- PHP >= 7.2 is now required due to "illuminate/support" >= 6.0
- Config variable "domains" changed to "domain" and must not be an array now -> https://github.com/imgix/imgix-php/pull/45
- Config variable "shardStrategy" removed due to same PR as above

Feel free to ask if something is not clear.