### PR TITLE
Update Travis CI for supported versions of PHP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: php
 
 php:
-    - 5.6
-    - 7.0
-    - 7.1
-    - hhvm
+    - 7.2
+    - 7.3
+    - 7.4
 
-dist: trusty
+dist: bionic
 sudo: false
 
 cache:


### PR DESCRIPTION
The README and composer.json files state that the minimum supported version of this package is 7.2, yet the Travis CI configuration targets earlier versions of PHP. This merge request is to update the Travis CI configuration for 7.2+ and to run the builds on a more recent LTS Ubuntu version.